### PR TITLE
Fix check version error

### DIFF
--- a/lib/main/redis.main.js
+++ b/lib/main/redis.main.js
@@ -112,10 +112,7 @@ Redis.prototype.connect = function() {
       var vers = client.server_info.versions;
       var verError = 'Kansas will only work with Redis Server v2.8.0 or later.' +
         ' Your version: ' + vers[0] + '.' + vers[1] + '.' + vers[2];
-      if (vers[0] < 2) {
-        return reject(verError);
-      }
-      if (vers[1] < 8) {
+      if (vers[0] < 2 && vers[1] < 8) {
         return reject(verError);
       }
       client.removeListener('error', onError);


### PR DESCRIPTION
Fix this error:
`Error on boot: Kansas will only work with Redis Server v2.8.0 or later. Your version: 3.0.0`

Credit for finding the if-case to @attheodo